### PR TITLE
スタッフクライアント連絡履歴画面のUI/UX権限制御情報表示の統一

### DIFF
--- a/apps/client/urls.py
+++ b/apps/client/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from .views import (
     client_list, client_create, client_detail, client_update, client_delete,
-    client_contacted_create, client_contacted_list, client_contacted_update, client_contacted_delete
+    client_contacted_create, client_contacted_list, client_contacted_update, client_contacted_delete, client_contacted_detail
 )
 
 app_name = 'client'
@@ -15,6 +15,7 @@ urlpatterns = [
     # クライアント連絡履歴
     path('client/<int:client_pk>/contacted/create/', client_contacted_create, name='client_contacted_create'),
     path('client/<int:client_pk>/contacted/list/', client_contacted_list, name='client_contacted_list'),
+    path('client/contacted/<int:pk>/detail/', client_contacted_detail, name='client_contacted_detail'),
     path('client/contacted/<int:pk>/update/', client_contacted_update, name='client_contacted_update'),
     path('client/contacted/<int:pk>/delete/', client_contacted_delete, name='client_contacted_delete'),
     # path("get_company_info/", get_company_info, name="get_company_info"),

--- a/apps/client/views.py
+++ b/apps/client/views.py
@@ -1,3 +1,12 @@
+# 連絡履歴 詳細
+from django.contrib.auth.decorators import permission_required
+
+@permission_required('client.view_clientcontacted', raise_exception=True)
+def client_contacted_detail(request, pk):
+    from .models import ClientContacted
+    contacted = get_object_or_404(ClientContacted, pk=pk)
+    client = contacted.client
+    return render(request, 'client/client_contacted_detail.html', {'contacted': contacted, 'client': client})
 from django.contrib.auth.decorators import login_required, permission_required
 def client_contacted_detail(request, pk):
     contacted = get_object_or_404(ClientContacted, pk=pk)

--- a/apps/staff/urls.py
+++ b/apps/staff/urls.py
@@ -2,7 +2,7 @@
 from django.urls import path
 from .views import (
     staff_list, staff_create, staff_detail, staff_update, staff_delete, staff_face, staff_rirekisho, staff_fuyokojo, staff_kyushoku,
-    staff_contacted_create, staff_contacted_list, staff_contacted_update, staff_contacted_delete
+    staff_contacted_create, staff_contacted_list, staff_contacted_update, staff_contacted_delete, staff_contacted_detail
 )
 
 urlpatterns = [
@@ -19,6 +19,7 @@ urlpatterns = [
     # 連絡履歴
     path('staff/<int:staff_pk>/contacted/create/', staff_contacted_create, name='staff_contacted_create'),
     path('staff/<int:staff_pk>/contacted/list/', staff_contacted_list, name='staff_contacted_list'),
+    path('staff/contacted/<int:pk>/detail/', staff_contacted_detail, name='staff_contacted_detail'),
     path('staff/contacted/<int:pk>/update/', staff_contacted_update, name='staff_contacted_update'),
     path('staff/contacted/<int:pk>/delete/', staff_contacted_delete, name='staff_contacted_delete'),
 ]

--- a/apps/staff/views.py
+++ b/apps/staff/views.py
@@ -1,3 +1,11 @@
+# 連絡履歴 詳細
+from django.contrib.auth.decorators import permission_required
+
+@permission_required('staff.view_staffcontacted', raise_exception=True)
+def staff_contacted_detail(request, pk):
+    contacted = get_object_or_404(StaffContacted, pk=pk)
+    staff = contacted.staff
+    return render(request, 'staff/staff_contacted_detail.html', {'contacted': contacted, 'staff': staff})
 import os
 import logging
 from PIL import Image, ImageDraw, ImageFont

--- a/templates/client/client_contacted_detail.html
+++ b/templates/client/client_contacted_detail.html
@@ -1,14 +1,72 @@
 {% extends 'common/base.html' %}
+{% load my_dropdown_tags %}
 {% block content %}
-<div class="container mt-4">
-  <h2>クライアント連絡履歴 詳細</h2>
-  <table class="table table-bordered">
-    <tr><th>クライアント</th><td>{{ client.name }}</td></tr>
-    <tr><th>連絡日時</th><td>{{ contacted.contacted_at|date:'Y/m/d H:i:s' }}</td></tr>
-    <tr><th>連絡種別</th><td>{{ contacted.get_contact_type_display|default:contacted.contact_type }}</td></tr>
-    <tr><th>対応内容</th><td>{{ contacted.content }}</td></tr>
-    <tr><th>対応詳細</th><td>{{ contacted.detail|linebreaksbr }}</td></tr>
-  </table>
-  <a href="{% url 'client:client_detail' client.id %}" class="btn btn-secondary">クライアント詳細へ戻る</a>
+<div class="content-box card bg-light mt-2 mb-4" style="max-width: 100%;">
+    <div class="card-header">
+        クライアント連絡履歴 詳細
+    </div>
+    <div class="card-body">
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>クライアント</strong></div>
+            <div class="col-sm-10">{{ client.name }}</div>
+        </div>
+        <!-- 対応者・日時は最後にまとめて表示 -->
+        </div>
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>連絡種別</strong></div>
+            <div class="col-sm-10">
+                {% if contacted.contact_type %}
+                    {% if contacted.contact_type < 10 %}
+                        <span class="badge bg-primary">{% my_name 'contact_type' contacted.contact_type %}</span>
+                    {% elif contacted.contact_type < 20 %}
+                        <span class="badge bg-success">{% my_name 'contact_type' contacted.contact_type %}</span>
+                    {% elif contacted.contact_type < 30 %}
+                        <span class="badge bg-info">{% my_name 'contact_type' contacted.contact_type %}</span>
+                    {% elif contacted.contact_type < 40 %}
+                        <span class="badge bg-warning">{% my_name 'contact_type' contacted.contact_type %}</span>
+                    {% elif contacted.contact_type < 50 %}
+                        <span class="badge bg-danger">{% my_name 'contact_type' contacted.contact_type %}</span>
+                    {% elif contacted.contact_type >= 90 %}
+                        <span class="badge bg-dark">{% my_name 'contact_type' contacted.contact_type %}</span>
+                    {% else %}
+                        <span class="badge bg-light">{% my_name 'contact_type' contacted.contact_type %}</span>
+                    {% endif %}
+                {% endif %}
+            </div>
+        </div>
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>対応内容</strong></div>
+            <div class="col-sm-10">{{ contacted.content }}</div>
+        </div>
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>対応詳細</strong></div>
+            <div class="col-sm-10">{{ contacted.detail|linebreaksbr }}</div>
+        </div>
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>対応者</strong></div>
+            <div class="col-sm-10">
+                {% if contacted.created_by.last_name or contacted.created_by.first_name %}
+                    {{ contacted.created_by.last_name }} {{ contacted.created_by.first_name }}
+                {% else %}
+                    {{ contacted.created_by.username }}
+                {% endif %}
+            </div>
+        </div>
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>連絡日時</strong></div>
+            <div class="col-sm-10">{{ contacted.contacted_at|date:'Y/m/d H:i:s' }}</div>
+        </div>
+        <div class="row mb-3 align-items-center mb-3">
+            <div class="col-12 d-flex justify-content-start align-items-center ms-3 mb-3">
+                {% if perms.client.change_clientcontacted %}
+                <a href="{% url 'client:client_contacted_update' contacted.pk %}" class="btn btn-sm btn-primary me-2">編集</a>
+                {% endif %}
+                {% if perms.client.delete_clientcontacted %}
+                <a href="{% url 'client:client_contacted_delete' contacted.pk %}" class="btn btn-sm btn-dark me-2">削除</a>
+                {% endif %}
+                <a href="{% url 'client:client_detail' client.id %}" class="btn btn-sm btn-secondary">戻る</a>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/templates/client/client_contacted_form.html
+++ b/templates/client/client_contacted_form.html
@@ -33,9 +33,6 @@
 
             <div class="d-flex justify-content-start">
                 <button type="submit" class="btn btn-sm btn-primary me-2">保存</button>
-                {% if contacted %}
-                <a href="{% url 'client:client_contacted_delete' contacted.pk %}" class="btn btn-sm btn-dark me-2">削除</a>
-                {% endif %}
                 <a href="{% url 'client:client_detail' client.pk %}" class="btn btn-sm btn-secondary me-2">戻る</a>
             </div>
         </form>

--- a/templates/client/client_contacted_list.html
+++ b/templates/client/client_contacted_list.html
@@ -12,6 +12,7 @@
                 <tr>
                     <th>連絡種別</th>
                     <th>対応内容</th>
+                    <th>対応者</th>
                     <th>日時</th>
                 </tr>
             </thead>
@@ -37,7 +38,14 @@
                             {% endif %}
                         {% endif %}
                     </td>
-                    <td><a href="{% url 'client:client_contacted_update' c.pk %}">{{ c.content|truncatechars:20 }}</a></td>
+                    <td><a href="{% url 'client:client_contacted_detail' c.pk %}">{{ c.content|truncatechars:20 }}</a></td>
+                    <td>
+                        {% if c.created_by.last_name or c.created_by.first_name %}
+                            {{ c.created_by.last_name }} {{ c.created_by.first_name }}
+                        {% else %}
+                            {{ c.created_by.username }}
+                        {% endif %}
+                    </td>
                     <td>{{ c.contacted_at|date:'Y/m/d H:i:s' }}</td>
                 </tr>
                 {% empty %}

--- a/templates/client/client_detail.html
+++ b/templates/client/client_detail.html
@@ -81,8 +81,12 @@
             </div>
 
             <div class="d-flex justify-content-start">
+                {% if perms.client.change_client %}
                 <a href="{% url 'client:client_update' client.pk %}" class="btn btn-sm btn-primary me-2">編集</a>
+                {% endif %}
+                {% if perms.client.delete_client %}
                 <a href="{% url 'client:client_delete' client.pk %}" class="btn btn-sm btn-dark me-2">削除</a>
+                {% endif %}
                 <a href="{% url 'client:client_list' %}" class="btn btn-sm btn-secondary me-2">戻る</a>
             </div>
     </div>
@@ -125,7 +129,9 @@
 <div class="content-box card bg-light mt-2 mb-4" style="max-width: 100%;">
     <div class="card-header d-flex justify-content-between align-items-center">
         クライアント連絡履歴
+        {% if perms.client.add_clientcontacted %}
         <a href="{% url 'client:client_contacted_create' client.id %}" class="btn btn-sm btn-primary">連絡登録</a>
+        {% endif %}
     </div>
     <div class="card-body mb-0" style="margin-bottom: 2rem;">
         <table class="table table-hover me-2 mt-2 mb-0" style="border-top: 1px solid #ddd;">
@@ -133,6 +139,7 @@
                 <tr>
                     <th>連絡種別</th>
                     <th>対応内容</th>
+                    <th>対応者</th>
                     <th>日時</th>
                 </tr>
             </thead>
@@ -158,7 +165,14 @@
                             {% endif %}
                         {% endif %}
                     </td>
-                    <td><a href="{% url 'client:client_contacted_update' contacted.pk %}">{{ contacted.content }}</a></td>
+                    <td><a href="{% url 'client:client_contacted_detail' contacted.pk %}">{{ contacted.content }}</a></td>
+                    <td>
+                        {% if contacted.created_by.last_name or contacted.created_by.first_name %}
+                            {{ contacted.created_by.last_name }} {{ contacted.created_by.first_name }}
+                        {% else %}
+                            {{ contacted.created_by.username }}
+                        {% endif %}
+                    </td>
                     <td>{{ contacted.contacted_at|date:'Y/m/d H:i:s' }}</td>
                 </tr>
                 {% empty %}

--- a/templates/client/client_list.html
+++ b/templates/client/client_list.html
@@ -4,7 +4,9 @@
 <div class="content-box card bg-light mt-2 mb-4" style="max-width: 100%;">
     <div class="card-header d-flex justify-content-between align-items-center">
         クライアント一覧
+        {% if perms.client.add_client %}
         <a href="{% url 'client:client_create' %}" class="btn btn-sm btn-primary me-2">新規作成</a>
+        {% endif %}
     </div>
     <div class="card-body">
         <!-- <h5 class="card-title">クライアント一覧</h5> -->
@@ -84,14 +86,16 @@
                     </td>
                     <td>
                         <!-- 編集アイコン -->
+                        {% if perms.client.change_client %}
                         <a href="{% url 'client:client_update' client.pk %}" class="btn btn-dark btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" title="編集">
                           <i class="bi bi-pencil"></i>
                         </a>
-                      
-                        <!-- 削除アイコン -->
+                        {% endif %}
+                        {% if perms.client.delete_client %}
                         <a href="{% url 'client:client_delete' client.pk %}" class="btn btn-dark btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" title="削除">
                           <i class="bi bi-x"></i>
                         </a>
+                        {% endif %}
                       </td>
                 </tr>
                 {% endfor %}

--- a/templates/staff/staff_contacted_confirm_delete.html
+++ b/templates/staff/staff_contacted_confirm_delete.html
@@ -5,8 +5,9 @@
     <div class="card-header">スタッフ連絡履歴 削除確認</div>
     <div class="card-body">
         <p>本当にこの連絡履歴を削除しますか？</p>
-        <ul>
-            <li>連絡種別:
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>連絡種別</strong></div>
+            <div class="col-sm-10">
                 {% if contacted.contact_type %}
                     {% if contacted.contact_type < 10 %}
                         <span class="badge bg-primary">{% my_name 'contact_type' contacted.contact_type %}</span>
@@ -24,16 +25,35 @@
                         <span class="badge bg-light">{% my_name 'contact_type' contacted.contact_type %}</span>
                     {% endif %}
                 {% endif %}
-            </li>
-            <li>対応内容: {{ contacted.content }}</li>
-            <li>対応詳細: {{ contacted.detail }}</li>
-            <li>日時: {{ contacted.contacted_at|date:'Y/m/d H:i:s' }}</li>
-        </ul>
+            </div>
+        </div>
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>対応内容</strong></div>
+            <div class="col-sm-10">{{ contacted.content }}</div>
+        </div>
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>対応詳細</strong></div>
+            <div class="col-sm-10">{{ contacted.detail|linebreaksbr }}</div>
+        </div>
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>対応者</strong></div>
+            <div class="col-sm-10">
+                {% if contacted.created_by.last_name or contacted.created_by.first_name %}
+                    {{ contacted.created_by.last_name }} {{ contacted.created_by.first_name }}
+                {% else %}
+                    {{ contacted.created_by.username }}
+                {% endif %}
+            </div>
+        </div>
+        <div class="row mb-3 align-items-center">
+            <div class="col-sm-2" style="text-align:right"><strong>日時</strong></div>
+            <div class="col-sm-10">{{ contacted.contacted_at|date:'Y/m/d H:i:s' }}</div>
+        </div>
         <form method="post">
             {% csrf_token %}
             <div class="d-flex justify-content-start">
                 <button type="submit" class="btn btn-sm btn-dark me-2">削除</button>
-                <a href="{% url 'staff_contacted_update' contacted.pk %}" class="btn btn-sm btn-secondary me-2">キャンセル</a>
+                <a href="{% url 'staff_contacted_detail' contacted.pk %}" class="btn btn-sm btn-secondary me-2">キャンセル</a>
             </div>
         </form>
     </div>

--- a/templates/staff/staff_contacted_detail.html
+++ b/templates/staff/staff_contacted_detail.html
@@ -2,9 +2,10 @@
 {% load my_dropdown_tags %}
 {% block content %}
 <div class="content-box card bg-light mt-2 mb-4" style="max-width: 100%;">
-    <div class="card-header">クライアント連絡履歴 削除確認</div>
+    <div class="card-header">
+        連絡履歴詳細
+    </div>
     <div class="card-body">
-        <p>本当にこの連絡履歴を削除しますか？</p>
         <div class="row mb-3 align-items-center">
             <div class="col-sm-2" style="text-align:right"><strong>連絡種別</strong></div>
             <div class="col-sm-10">
@@ -29,10 +30,6 @@
         </div>
         <div class="row mb-3 align-items-center">
             <div class="col-sm-2" style="text-align:right"><strong>対応内容</strong></div>
-            <div class="col-sm-10">{{ contacted.content }}</div>
-        </div>
-        <div class="row mb-3 align-items-center">
-            <div class="col-sm-2" style="text-align:right"><strong>対応詳細</strong></div>
             <div class="col-sm-10">{{ contacted.detail|linebreaksbr }}</div>
         </div>
         <div class="row mb-3 align-items-center">
@@ -49,13 +46,16 @@
             <div class="col-sm-2" style="text-align:right"><strong>日時</strong></div>
             <div class="col-sm-10">{{ contacted.contacted_at|date:'Y/m/d H:i:s' }}</div>
         </div>
-        <form method="post">
-            {% csrf_token %}
-            <div class="d-flex justify-content-start">
-                <button type="submit" class="btn btn-sm btn-dark me-2">削除</button>
-                <a href="{% url 'client:client_contacted_detail' contacted.pk %}" class="btn btn-sm btn-secondary me-2">キャンセル</a>
+        <div class="row mb-3 align-items-center">
+            <div class="col-12 d-flex justify-content-start align-items-center">
+                {% if perms.staff.change_staffcontacted %}
+                <a href="{% url 'staff_contacted_update' contacted.pk %}" class="btn btn-sm btn-primary me-2">編集</a>
+                {% endif %}
+                {% if perms.staff.delete_staffcontacted %}
+                <a href="{% url 'staff_contacted_delete' contacted.pk %}" class="btn btn-sm btn-dark me-2">削除</a>
+                {% endif %}
+                <a href="{% url 'staff_detail' staff.pk %}" class="btn btn-sm btn-secondary">戻る</a>
             </div>
-        </form>
-    </div>
+        </div>
 </div>
 {% endblock %}

--- a/templates/staff/staff_contacted_form.html
+++ b/templates/staff/staff_contacted_form.html
@@ -33,9 +33,6 @@
 
             <div class="d-flex justify-content-start">
                 <button type="submit" class="btn btn-sm btn-primary me-2">保存</button>
-                {% if contacted %}
-                <a href="{% url 'staff_contacted_delete' contacted.pk %}" class="btn btn-sm btn-dark me-2">削除</a>
-                {% endif %}
                 <a href="{% url 'staff_detail' staff.pk %}" class="btn btn-sm btn-secondary me-2">戻る</a>
             </div>
         </form>

--- a/templates/staff/staff_contacted_list.html
+++ b/templates/staff/staff_contacted_list.html
@@ -12,6 +12,7 @@
                 <tr>
                     <th>連絡種別</th>
                     <th>対応内容</th>
+                    <th>対応者</th>
                     <th>日時</th>
                 </tr>
             </thead>
@@ -37,7 +38,14 @@
                             {% endif %}
                         {% endif %}
                     </td>
-                    <td><a href="{% url 'staff_contacted_update' c.pk %}">{{ c.content|truncatechars:20 }}</a></td>
+                    <td><a href="{% url 'staff_contacted_detail' c.pk %}">{{ c.content|truncatechars:20 }}</a></td>
+                    <td>
+                        {% if c.created_by.last_name or c.created_by.first_name %}
+                            {{ c.created_by.last_name }} {{ c.created_by.first_name }}
+                        {% else %}
+                            {{ c.created_by.username }}
+                        {% endif %}
+                    </td>
                     <td>{{ c.contacted_at|date:'Y/m/d H:i:s' }}</td>
                 </tr>
                 {% empty %}

--- a/templates/staff/staff_detail.html
+++ b/templates/staff/staff_detail.html
@@ -103,8 +103,12 @@
                     </div>
 
                     <div class="d-flex justify-content-start">
+                        {% if perms.staff.change_staff %}
                         <a href="{% url 'staff_update' staff.pk %}" class="btn btn-sm btn-primary me-2">編集</a>
+                        {% endif %}
+                        {% if perms.staff.delete_staff %}
                         <a href="{% url 'staff_delete' staff.pk %}" class="btn btn-sm btn-dark me-2">削除</a>
+                        {% endif %}
                         <a href="{% url 'staff_list' %}" class="btn btn-sm btn-secondary me-2">戻る</a>
                     </div>
             </div>
@@ -207,7 +211,9 @@
 <div class="content-box card bg-light mt-2 mb-4" style="max-width: 100%;">
     <div class="card-header d-flex justify-content-between align-items-center">
         連絡履歴
+        {% if perms.staff.add_staffcontacted %}
         <a href="{% url 'staff_contacted_create' staff.pk %}" class="btn btn-sm btn-primary me-2">連絡登録</a>
+        {% endif %}
     </div>
     <div class="card-body mb-0">
         <table class="table table-hover me-2 mt-2 mb-0" style="border-top: 1px solid #ddd;">
@@ -215,6 +221,7 @@
                 <tr>
                     <th>連絡種別</th>
                     <th>対応内容</th>
+                    <th>対応者</th>
                     <th>日時</th>
                 </tr>
             </thead>
@@ -240,7 +247,14 @@
                             {% endif %}
                         {% endif %}
                     </td>
-                    <td><a href="{% url 'staff_contacted_update' c.pk %}">{{ c.content|truncatechars:20 }}</a></td>
+                    <td><a href="{% url 'staff_contacted_detail' c.pk %}">{{ c.content|truncatechars:20 }}</a></td>
+                    <td>
+                        {% if c.created_by.last_name or c.created_by.first_name %}
+                            {{ c.created_by.last_name }} {{ c.created_by.first_name }}
+                        {% else %}
+                            {{ c.created_by.username }}
+                        {% endif %}
+                    </td>
                     <td>{{ c.contacted_at|date:'Y/m/d H:i:s' }}</td>
                 </tr>
                 {% empty %}

--- a/templates/staff/staff_list.html
+++ b/templates/staff/staff_list.html
@@ -4,7 +4,9 @@
 <div class="content-box card bg-light mt-2 mb-4" style="max-width: 100%;">
     <div class="card-header d-flex justify-content-between align-items-center">
         スタッフ一覧
+        {% if perms.staff.add_staff %}
         <a href="{% url 'staff_create' %}" class="btn btn-sm btn-primary me-2">新規作成</a>
+        {% endif %}
     </div>
     <div class="card-body">
         <!--
@@ -74,14 +76,17 @@
                     </td>
                     <td>
                         <!-- 編集アイコン -->
+                        {% if perms.staff.change_staff %}
                         <a href="{% url 'staff_update' staff.pk %}" class="btn btn-dark btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" title="編集">
                           <i class="bi bi-pencil"></i>
                         </a>
-                      
+                        {% endif %}
                         <!-- 削除アイコン -->
+                        {% if perms.staff.delete_staff %}
                         <a href="{% url 'staff_delete' staff.pk %}" class="btn btn-dark btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" title="削除">
                           <i class="bi bi-x"></i>
                         </a>
+                        {% endif %}
                       </td>
                 </tr>
                 {% endfor %}


### PR DESCRIPTION
- スタッフ・クライアント連絡履歴の詳細・一覧・削除画面のUI/UX統一
- 対応者表示（姓＋名）・ボタン余白・配置・権限制御・遷移先修正
- Bootstrapクラスで余白調整