### PR TITLE
Redesign home page summary and add tests

### DIFF
--- a/apps/home/tests/test_views.py
+++ b/apps/home/tests/test_views.py
@@ -1,0 +1,55 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+from apps.accounts.models import MyUser
+
+class HomeViewTest(TestCase):
+    def setUp(self):
+        """
+        テストデータのセットアップ
+        """
+        self.client = Client()
+        self.user = MyUser.objects.create_user(
+            username='testuser@example.com',
+            email='testuser@example.com',
+            password='password',
+            first_name='Test',
+            last_name='User',
+        )
+        self.home_url = reverse('home:home')
+
+    def test_home_view_redirects_for_anonymous_user(self):
+        """
+        未ログインユーザーはログインページにリダイレクトされることをテスト
+        """
+        response = self.client.get(self.home_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, f'/accounts/login/?next={self.home_url}')
+
+    def test_home_view_loads_for_logged_in_user(self):
+        """
+        ログイン済みユーザーでホーム画面が正常に表示されることをテスト
+        """
+        self.client.login(email='testuser@example.com', password='password')
+        response = self.client.get(self.home_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'home/home.html')
+
+    def test_home_view_context_data(self):
+        """
+        ホーム画面のコンテキストデータが正しく渡されていることをテスト
+        """
+        self.client.login(email='testuser@example.com', password='password')
+        response = self.client.get(self.home_url)
+        self.assertEqual(response.status_code, 200)
+
+        # コンテキストのキーが存在するかチェック
+        self.assertIn('staff_count', response.context)
+        self.assertIn('approved_staff_count', response.context)
+        self.assertIn('client_count', response.context)
+        self.assertIn('approved_client_count', response.context)
+        self.assertIn('client_contract_count', response.context)
+        self.assertIn('current_client_contracts', response.context)
+        self.assertIn('recent_client_contracts', response.context)
+        self.assertIn('staff_contract_count', response.context)
+        self.assertIn('current_staff_contracts', response.context)
+        self.assertIn('recent_staff_contracts', response.context)

--- a/apps/home/views.py
+++ b/apps/home/views.py
@@ -13,14 +13,31 @@ def home(request):
     client_count = Client.objects.count()
     approved_client_count = ConnectClient.objects.filter(status='approved').count()
 
-    contract_count = ClientContract.objects.count() + StaffContract.objects.count()
+    # 契約情報の取得
+    client_contract_count = ClientContract.objects.count()
+    current_client_contracts = ClientContract.objects.filter(is_active=True).count()
+    recent_client_contracts = ClientContract.objects.select_related('client').filter(
+        is_active=True
+    ).order_by('-created_at')[:5]
+
+    staff_contract_count = StaffContract.objects.count()
+    current_staff_contracts = StaffContract.objects.filter(is_active=True).count()
+    recent_staff_contracts = StaffContract.objects.select_related('staff').filter(
+        is_active=True
+    ).order_by('-created_at')[:5]
 
     context = {
         'staff_count': staff_count,
         'approved_staff_count': approved_staff_count,
         'client_count': client_count,
         'approved_client_count': approved_client_count,
-        'contract_count': contract_count,
+
+        'client_contract_count': client_contract_count,
+        'current_client_contracts': current_client_contracts,
+        'recent_client_contracts': recent_client_contracts,
+        'staff_contract_count': staff_contract_count,
+        'current_staff_contracts': current_staff_contracts,
+        'recent_staff_contracts': recent_staff_contracts,
     }
 
     return render(request, 'home/home.html', context)

--- a/templates/home/home.html
+++ b/templates/home/home.html
@@ -14,30 +14,114 @@
         <div class="card-header">サマリー</div>
         <div class="card-body">
             <div class="row">
-                <div class="col-md-4">
-                    <div class="card text-center mb-3">
-                        <div class="card-header">スタッフ</div>
+                <!-- クライアント契約 -->
+                <div class="col-md-6 mb-4">
+                    <div class="card bg-light h-100">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <span>
+                                <i class="bi bi-building text-primary"></i>
+                                クライアント契約
+                            </span>
+                            <a href="{% url 'contract:client_contract_create' %}" class="btn btn-sm btn-primary">新規作成</a>
+                        </div>
                         <div class="card-body">
-                            <p class="card-text">登録数: {{ staff_count }}</p>
-                            <p class="card-text">うち接続承認済: {{ approved_staff_count }}</p>
+                            <div class="row text-center mb-3">
+                                <div class="col-6">
+                                    <h4 class="text-primary">{{ current_client_contracts }}</h4>
+                                    <small class="text-muted">現在有効</small>
+                                </div>
+                                <div class="col-6">
+                                    <h4 class="text-secondary">{{ client_contract_count }}</h4>
+                                    <small class="text-muted">総契約数</small>
+                                </div>
+                            </div>
+
+                            <h6>最新の契約</h6>
+                            {% if recent_client_contracts %}
+                                <div class="list-group list-group-flush">
+                                    {% for contract in recent_client_contracts %}
+                                    <a href="{% url 'contract:client_contract_detail' contract.pk %}" class="list-group-item list-group-item-action">
+                                        <div class="d-flex w-100 justify-content-between">
+                                            <h6 class="mb-1">{{ contract.contract_name }}</h6>
+                                            <small>{{ contract.start_date|date:'Y/m/d' }}</small>
+                                        </div>
+                                        <p class="mb-1">{{ contract.client.name }}</p>
+                                        <small>
+                                            {% if contract.status == '有効' %}
+                                                <span class="badge bg-success">{{ contract.status }}</span>
+                                            {% elif contract.status == '開始前' %}
+                                                <span class="badge bg-warning">{{ contract.status }}</span>
+                                            {% elif contract.status == '終了' %}
+                                                <span class="badge bg-secondary">{{ contract.status }}</span>
+                                            {% else %}
+                                                <span class="badge bg-danger">{{ contract.status }}</span>
+                                            {% endif %}
+                                        </small>
+                                    </a>
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <p class="text-muted">契約がありません</p>
+                            {% endif %}
+                        </div>
+                        <div class="card-footer">
+                            <a href="{% url 'contract:client_contract_list' %}" class="btn btn-sm btn-outline-primary">全て表示</a>
                         </div>
                     </div>
                 </div>
-                <div class="col-md-4">
-                    <div class="card text-center mb-3">
-                        <div class="card-header">クライアント</div>
-                        <div class="card-body">
-                            <p class="card-text">登録数: {{ client_count }}</p>
-                            <p class="card-text">うち接続承認済: {{ approved_client_count }}</p>
+
+                <!-- スタッフ契約 -->
+                <div class="col-md-6 mb-4">
+                    <div class="card bg-light h-100">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <span>
+                                <i class="bi bi-people text-success"></i>
+                                スタッフ契約
+                            </span>
+                            <a href="{% url 'contract:staff_contract_create' %}" class="btn btn-sm btn-success">新規作成</a>
                         </div>
-                    </div>
-                </div>
-                <div class="col-md-4">
-                    <div class="card text-center mb-3">
-                        <div class="card-header">契約</div>
                         <div class="card-body">
-                            <p class="card-text">契約数: {{ contract_count }}</p>
-                            <p class="card-text">&nbsp;</p>
+                            <div class="row text-center mb-3">
+                                <div class="col-6">
+                                    <h4 class="text-success">{{ current_staff_contracts }}</h4>
+                                    <small class="text-muted">現在有効</small>
+                                </div>
+                                <div class="col-6">
+                                    <h4 class="text-secondary">{{ staff_contract_count }}</h4>
+                                    <small class="text-muted">総契約数</small>
+                                </div>
+                            </div>
+
+                            <h6>最新の契約</h6>
+                            {% if recent_staff_contracts %}
+                                <div class="list-group list-group-flush">
+                                    {% for contract in recent_staff_contracts %}
+                                    <a href="{% url 'contract:staff_contract_detail' contract.pk %}" class="list-group-item list-group-item-action">
+                                        <div class="d-flex w-100 justify-content-between">
+                                            <h6 class="mb-1">{{ contract.contract_name }}</h6>
+                                            <small>{{ contract.start_date|date:'Y/m/d' }}</small>
+                                        </div>
+                                        <p class="mb-1">{{ contract.staff.name_last }} {{ contract.staff.name_first }}</p>
+                                        <small>
+                                            {% if contract.status == '有効' %}
+                                                <span class="badge bg-success">{{ contract.status }}</span>
+                                            {% elif contract.status == '開始前' %}
+                                                <span class="badge bg-warning">{{ contract.status }}</span>
+                                            {% elif contract.status == '終了' %}
+                                                <span class="badge bg-secondary">{{ contract.status }}</span>
+                                            {% else %}
+                                                <span class="badge bg-danger">{{ contract.status }}</span>
+                                            {% endif %}
+                                        </small>
+                                    </a>
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <p class="text-muted">契約がありません</p>
+                            {% endif %}
+                        </div>
+                        <div class="card-footer">
+                            <a href="{% url 'contract:staff_contract_list' %}" class="btn btn-sm btn-outline-success">全て表示</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- Replaced the existing "サマリー" (Summary) section in `templates/home/home.html` with a new layout based on `templates/contract/contract_index.html`.
- Modified `apps/home/views.py` to fetch detailed contract information (active counts, total counts, and recent contracts) for the new summary section.
- Added a new test suite for the `home` app in `apps/home/tests/test_views.py`.
- The new tests verify that the home page requires login, loads correctly for authenticated users, and receives the correct context data.