### PR TITLE
Conditionally display staff request link based on permissions

### DIFF
--- a/apps/home/tests/test_views.py
+++ b/apps/home/tests/test_views.py
@@ -1,5 +1,6 @@
 from django.test import TestCase, Client
 from django.urls import reverse
+from django.contrib.auth.models import Permission
 from apps.accounts.models import MyUser
 from apps.staff.models import Staff
 from apps.connect.models import ConnectStaff, MynumberRequest
@@ -52,10 +53,13 @@ class HomeViewTest(TestCase):
         self.assertIn('client_count', response.context)
         self.assertIn('approved_client_count', response.context)
 
-    def test_home_view_staff_request_count(self):
+    def test_home_view_staff_request_count_with_permission(self):
         """
-        Test that staff_request_count is calculated correctly and the link is present.
+        Test that staff_request_count is calculated correctly and the link is present for a user with permission.
         """
+        # Add permission to user
+        permission = Permission.objects.get(codename='view_staff')
+        self.user.user_permissions.add(permission)
         self.client.login(email='testuser@example.com', password='password')
 
         # Create staff user
@@ -95,6 +99,50 @@ class HomeViewTest(TestCase):
         self.assertIn('staff_request_count', response.context)
         self.assertEqual(response.context['staff_request_count'], 1)
         self.assertContains(response, f'href="{reverse("staff:staff_list")}?has_request=true"')
+
+    def test_home_view_staff_request_count_no_permission(self):
+        """
+        Test that the link is not present for a user without permission.
+        """
+        self.client.login(email='testuser@example.com', password='password')
+
+        # Create staff user
+        staff_user = MyUser.objects.create_user(
+            username='staffuser@example.com',
+            email='staff@example.com',
+            password='password',
+        )
+        # Create mynumber profile
+        staff_mynumber = StaffProfileMynumber.objects.create(
+            user=staff_user,
+            mynumber='123456789012'
+        )
+
+        # Create Staff data
+        Staff.objects.create(email='staff@example.com')
+
+        # Create ConnectStaff data
+        connect_staff = ConnectStaff.objects.create(
+            corporate_number='1234567890123',
+            email='staff@example.com',
+            status='approved'
+        )
+
+        # Create a pending request
+        MynumberRequest.objects.create(
+            connect_staff=connect_staff,
+            profile_mynumber=staff_mynumber,
+            status='pending'
+        )
+
+        # Create another staff without request
+        Staff.objects.create(email='norequest@example.com')
+
+        response = self.client.get(self.home_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('staff_request_count', response.context)
+        self.assertEqual(response.context['staff_request_count'], 1)
+        self.assertNotContains(response, f'href="{reverse("staff:staff_list")}?has_request=true"')
 
     def test_home_view_staff_request_count_zero(self):
         """

--- a/templates/home/home.html
+++ b/templates/home/home.html
@@ -56,7 +56,7 @@
                                     <small class="text-muted">接続承認済み</small>
                                 </div>
                                 <div class="col-4">
-                                    {% if staff_request_count > 0 %}
+                                    {% if staff_request_count > 0 and perms.staff.view_staff %}
                                     <a href="{% url 'staff:staff_list' %}?has_request=true" class="text-decoration-none">
                                         <h4 class="text-warning">{{ staff_request_count }}</h4>
                                         <small class="text-muted">申請あり</small>


### PR DESCRIPTION
On the home page, the link to the staff list with pending requests was visible to all users, which could lead to a 403 error for users without the necessary permissions.

This change modifies the home.html template to only render the link for users who have the 'staff.view_staff' permission.

Additionally, the tests for the home view have been updated to verify this new behavior. A test has been added to ensure the link is not visible for users without the permission, and the existing test has been updated to grant the permission to the test user.