### PR TITLE
Add pagination footer to kintai search and management pages

### DIFF
--- a/apps/kintai/views.py
+++ b/apps/kintai/views.py
@@ -147,8 +147,14 @@ def contract_search(request):
             'required_days': required_days, # デバッグ表示用などに持たせておく
         })
 
+    from django.core.paginator import Paginator
+    paginator = Paginator(contract_list, 20)
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
     context = {
-        'contract_list': contract_list,
+        'contract_list': page_obj,
+        'page_obj': page_obj,
         'year': year,
         'month': month,
         'target_date': target_date,
@@ -231,8 +237,14 @@ def staff_search(request):
             'input_days': input_days,
         })
 
+    from django.core.paginator import Paginator
+    paginator = Paginator(staff_list, 20)
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
     context = {
-        'staff_list': staff_list,
+        'staff_list': page_obj,
+        'page_obj': page_obj,
         'year': year,
         'month': month,
         'target_date': target_date,
@@ -1811,8 +1823,14 @@ def client_contract_search(request):
     if staff_to_annotate:
         annotate_staff_connection_info(staff_to_annotate)
 
+    from django.core.paginator import Paginator
+    paginator = Paginator(assignment_list, 20)
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
     context = {
-        'assignment_list': assignment_list,
+        'assignment_list': page_obj,
+        'page_obj': page_obj,
         'year': year,
         'month': month,
         'target_date': target_date,
@@ -2504,8 +2522,14 @@ def kintai_status_management(request):
         if status in status_summary:
             status_summary[status] += 1
     
+    from django.core.paginator import Paginator
+    paginator = Paginator(contract_status_list, 20)
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
     context = {
-        'contract_status_list': contract_status_list,
+        'contract_status_list': page_obj,
+        'page_obj': page_obj,
         'status_summary': status_summary,
         'year': year,
         'month': month,

--- a/templates/kintai/client_contract_search.html
+++ b/templates/kintai/client_contract_search.html
@@ -119,6 +119,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            {% include 'common/_pagination.html' %}
         {% else %}
             <p class="text-muted">対象の契約が見つかりませんでした。</p>
         {% endif %}

--- a/templates/kintai/contract_search.html
+++ b/templates/kintai/contract_search.html
@@ -141,6 +141,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            {% include 'common/_pagination.html' %}
         {% else %}
             <p class="text-muted">該当する契約が見つかりませんでした。</p>
         {% endif %}

--- a/templates/kintai/kintai_status_management.html
+++ b/templates/kintai/kintai_status_management.html
@@ -37,7 +37,7 @@
         <span><i class="bi bi-clipboard-check me-2"></i>勤怠登録状況管理</span>
         <div class="text-end">
             <small class="text-muted">
-                対象契約数: <strong>{{ contract_status_list|length }}</strong>件
+                対象契約数: <strong>{{ contract_status_list.paginator.count }}</strong>件
             </small>
         </div>
     </div>
@@ -235,6 +235,8 @@
                 </tbody>
             </table>
         </div>
+
+        {% include 'common/_pagination.html' %}
 
         <div class="mt-4 legend-box shadow-sm">
             <h6 class="border-bottom pb-2 mb-3 fw-bold"><i class="bi bi-info-circle me-2"></i>凡例と処理フロー</h6>

--- a/templates/kintai/staff_search.html
+++ b/templates/kintai/staff_search.html
@@ -64,6 +64,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            {% include 'common/_pagination.html' %}
         {% else %}
             <p class="text-muted">該当するスタッフが見つかりませんでした。</p>
         {% endif %}


### PR DESCRIPTION
This change adds a common pagination footer to four key pages in the kintai application:
1. Staff Contract Search (/kintai/contract/search/)
2. Staff Search (/kintai/staff/search/)
3. Client Contract Search (/kintai/client/contract/search/)
4. Attendance Status Management (/kintai/status/management/)

The implementation follows the project's standard pattern of using Django's Paginator (20 items per page) and the 'common/_pagination.html' template component, which displays the record range and total count in the requested format (e.g., "（全3件中 1～3件を表示）").

Validation:
- Unit tests for all four views passed.
- Frontend verification via Playwright confirmed correct rendering of the footer on all target pages.
- Code review confirmed adherence to repository standards.

---
*PR created automatically by Jules for task [4286834965146168413](https://jules.google.com/task/4286834965146168413) started by @chocoapricot*